### PR TITLE
[fix: Login Response]

### DIFF
--- a/src/main/java/com/driveu/server/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/driveu/server/domain/auth/dto/LoginResponse.java
@@ -2,6 +2,7 @@ package com.driveu.server.domain.auth.dto;
 
 
 import com.driveu.server.domain.directory.dto.response.DirectoryTreeResponse;
+import com.driveu.server.domain.semester.dto.response.UserSemesterResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +16,7 @@ import java.util.List;
 @Builder
 public class LoginResponse {
     private UserInfo user;
-    private SemesterInfo semester;
+    private List<UserSemesterResponse> semesters;
     private TokenInfo token;
     private List<DirectoryTreeResponse> directories;
 
@@ -26,16 +27,6 @@ public class LoginResponse {
     public static class UserInfo {
         private Long userId;
         private String name;
-    }
-
-    @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
-    public static class SemesterInfo {
-        private Long id;
-        private int year;
-        private String term;
     }
 
     @Getter


### PR DESCRIPTION
﻿### 🥕 ISSUE

- closed #27 

---

### ✅ Key Changes
- semester -> semesters로 key 변경
- 로그인 시 사용자의 모든 semester semester list 형식으로 반환
```
{
  "user": {
    "userId": 0,
    "name": "string"
  },
  "semesters": [
    {
      "userSemesterId": 1,
      "year": 2025,
      "term": "SPRING",
      "isCurrent": true
    },
    {
      "userSemesterId": 2,
      "year": 2024,
      "term": "WINTER",
      "isCurrent": false
    }
  ],
  "token": {
    "accessToken": "string",
    "refreshToken": "string"
  },
  "directories": [
    {
      "id": 0,
      "name": "string",
      "order": 0,
      "is_default": true
    }
  ]
}
```
---

### 📢 To Reviewers

---

### 📸 ScreenShot
