### PR TITLE
[Feat] Spring Batch 내결함성 전략 적용 (Retry/Skip/Restart)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,142 @@ docker run -p 8080:8080 \
 
 ---
 
+## ♻️ 배치 시스템 - 휴지통 리소스 자동 정리
+
+### 개요
+
+`trashCleanupJob`은 휴지통에 30일 이상 보관된 리소스와 디렉토리를 영구 삭제하는 Spring Batch Job입니다.
+두 개의 Step이 순서대로 실행되며, 각 Step은 `ItemStreamReader` 기반 커서 버퍼 방식으로 대용량 데이터를 처리합니다.
+
+| Job | Step | 처리 대상 | Chunk Size |
+|---|---|---|---|
+| `trashCleanupJob` | `resourceCleanupStep` | 만료된 `Resource` (File / Note / Link) | 100 |
+| `trashCleanupJob` | `directoryCleanupStep` | 만료된 `Directory` | 100 |
+
+---
+
+### 처리 흐름
+
+**Step 1 — resourceCleanupStep**
+
+```
+ExpiredResourceReader
+  └─ DB에서 baseTime 이전에 삭제된 Resource를 100건씩 커서 조회
+       │
+       ▼ (no Processor)
+ResourceCleanupWriter
+  ├─ 1. QuestionResource 연결 삭제
+  ├─ 2. Summary 삭제 (Note 타입인 경우)
+  ├─ 3. ResourceDirectory 삭제
+  ├─ 4. S3 파일 삭제 (CircuitBreaker: s3Delete)
+  ├─ 5. Resource DB 영구 삭제
+  └─ 6. 사용자 usedStorage 차감 (벌크 UPDATE)
+```
+
+**Step 2 — directoryCleanupStep**
+
+```
+ExpiredDirectoryReader
+  └─ DB에서 baseTime 이전에 삭제된 Directory를 100건씩 커서 조회
+       │
+       ▼ (no Processor)
+DirectoryCleanupWriter
+  ├─ 1. DirectoryHierarchy 삭제 (Closure Table 연결 행 제거)
+  ├─ 2. ResourceDirectory 삭제
+  └─ 3. Directory DB 영구 삭제
+```
+
+---
+
+### 내결함성 전략
+
+#### Retry (`resourceCleanupStep`)
+
+| 항목 | 값 |
+|---|---|
+| 재시도 대상 예외 | `AmazonS3Exception`, `TransientDataAccessException` |
+| 최대 재시도 횟수 | 3회 (`retryLimit = 3`) |
+| 백오프 전략 | Exponential Backoff — 초기 1초, 배수 2.0x, 최대 10초 |
+| 리스너 | `S3RetryListener` — 재시도 횟수·예외 로깅 |
+
+```java
+.retryLimit(3)
+.backOffPolicy(new ExponentialBackOffPolicy() {{
+    setInitialInterval(1000);  // 1초
+    setMultiplier(2.0);        // 2배씩
+    setMaxInterval(10000);     // 최대 10초
+}})
+```
+
+#### Skip
+
+| Step | Skip 대상 예외 | skipLimit | 리스너 |
+|---|---|---|---|
+| `resourceCleanupStep` | `AmazonS3Exception` (retry 소진 후), `CallNotPermittedException` (Circuit OPEN 즉시) | 50 | `ResourceSkipListener` |
+| `directoryCleanupStep` | [TODO: 명시적 skip 예외 미설정] | 20 | `DirectorySkipListener` |
+
+Skip 발생 시 `SkipLog` 엔티티가 `skip_log` 테이블에 기록됩니다.
+
+```
+skip_log { stepName, resourceId, reason, skippedAt }
+  예) stepName = "RESOURCE_WRITE_CIRCUIT_OPEN"
+      stepName = "RESOURCE_WRITE"
+      stepName = "RESOURCE_PROCESS"
+      stepName = "DIRECTORY_WRITE"
+```
+
+#### Circuit Breaker (Resilience4j)
+
+S3 삭제 요청에 `s3Delete` Circuit Breaker가 적용됩니다.
+Circuit이 OPEN 상태일 때 `CallNotPermittedException`이 발생하며, 이는 즉시 Skip 처리됩니다.
+
+#### Restart (체크포인트)
+
+두 Reader 모두 `ItemStreamReader`를 구현하여 청크 커밋마다 `ExecutionContext`에 마지막 처리 ID를 저장합니다.
+장애 재시작 시 저장된 ID 이후부터 재개하므로 중복·누락이 없습니다.
+
+| Step | ExecutionContext 키 | 저장 값 |
+|---|---|---|
+| `resourceCleanupStep` | `resource.last.id` | 마지막으로 처리된 `Resource` ID |
+| `directoryCleanupStep` | `directory.last.id` | 마지막으로 처리된 `Directory` ID |
+
+#### Step startLimit
+
+두 Step 모두 `startLimit = 3`으로 설정되어 있어, 동일 JobInstance 내에서 Step의 무한 재시작을 방지합니다.
+
+---
+
+### 실행 조건
+
+#### 자동 실행 (스케줄러)
+
+`TrashCleanupScheduler`가 매일 자정에 Job을 실행합니다.
+
+```
+cron = "0 0 0 * * *"   →   매일 00:00:00
+baseTime = 현재 시각 - 30일  →  30일 이전에 soft delete된 항목만 대상
+```
+
+실패 시 즉시 1회 자동 재시작을 시도합니다 (`MAX_ATTEMPTS = 2`).
+Spring Batch는 동일 JobParameters로 재실행하면 실패한 Step부터 이어서 처리합니다.
+
+#### 수동 실행 (dev 프로필 전용)
+
+`BatchJobController`는 `@Profile("dev")`로 제한되어 운영 환경에 노출되지 않습니다.
+
+```bash
+# 수동 실행 (기본 30일, 변경 가능)
+POST /internal/batch/trash-cleanup?daysAgo=30
+
+# 마지막 실패 실행 조회
+GET /internal/batch/trash-cleanup/last-failed
+
+# 마지막 실패 실행 재시작
+POST /internal/batch/trash-cleanup/restart
+```
+
+---
+
 ## 👥 Contributors
 
 2025 졸업 프로젝트 팀 — DriveU

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    // Spring Batch
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+    testImplementation 'org.springframework.batch:spring-batch-test'
+
+    // Resilience4j Circuit Breaker
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+
     // Flyway
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'

--- a/src/main/java/com/driveu/server/domain/batch/dao/SkipLogRepository.java
+++ b/src/main/java/com/driveu/server/domain/batch/dao/SkipLogRepository.java
@@ -1,0 +1,7 @@
+package com.driveu.server.domain.batch.dao;
+
+import com.driveu.server.domain.batch.domain.SkipLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SkipLogRepository extends JpaRepository<SkipLog, Long> {
+}

--- a/src/main/java/com/driveu/server/domain/batch/domain/SkipLog.java
+++ b/src/main/java/com/driveu/server/domain/batch/domain/SkipLog.java
@@ -1,0 +1,53 @@
+package com.driveu.server.domain.batch.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "skip_log")
+public class SkipLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "step_name", nullable = false)
+    private String stepName;
+
+    @Column(name = "resource_id")
+    private Long resourceId;
+
+    @Column(name = "reason", nullable = false, columnDefinition = "TEXT")
+    private String reason;
+
+    @Column(name = "skipped_at", nullable = false)
+    private LocalDateTime skippedAt;
+
+    @Builder
+    private SkipLog(String stepName, Long resourceId, String reason, LocalDateTime skippedAt) {
+        this.stepName = stepName;
+        this.resourceId = resourceId;
+        this.reason = reason;
+        this.skippedAt = skippedAt;
+    }
+
+    public static SkipLog of(String stepName, Long resourceId, String reason) {
+        return SkipLog.builder()
+                .stepName(stepName)
+                .resourceId(resourceId)
+                .reason(reason)
+                .skippedAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/driveu/server/domain/directory/dao/DirectoryRepository.java
+++ b/src/main/java/com/driveu/server/domain/directory/dao/DirectoryRepository.java
@@ -3,13 +3,12 @@ package com.driveu.server.domain.directory.dao;
 import com.driveu.server.domain.directory.domain.Directory;
 import com.driveu.server.domain.semester.domain.UserSemester;
 import java.time.LocalDateTime;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DirectoryRepository extends JpaRepository<Directory, Long> {
 
@@ -78,4 +77,16 @@ public interface DirectoryRepository extends JpaRepository<Directory, Long> {
     Optional<Directory> findByIdAndIsDeletedTrue(Long id);
 
     List<Directory> findAllByIsDeletedTrueAndDeletedAtBefore(LocalDateTime deletedAtBefore);
+
+    @Query("""
+        SELECT d FROM Directory d
+        WHERE d.isDeleted = true
+        AND d.deletedAt < :baseTime
+        AND d.id > :lastId
+        ORDER BY d.id ASC
+        LIMIT 1
+        """)
+    Optional<Directory> findFirstExpiredDirectory(
+        @Param("baseTime") LocalDateTime baseTime,
+        @Param("lastId") long lastId);
 }

--- a/src/main/java/com/driveu/server/domain/directory/dao/DirectoryRepository.java
+++ b/src/main/java/com/driveu/server/domain/directory/dao/DirectoryRepository.java
@@ -84,9 +84,10 @@ public interface DirectoryRepository extends JpaRepository<Directory, Long> {
         AND d.deletedAt < :baseTime
         AND d.id > :lastId
         ORDER BY d.id ASC
-        LIMIT 1
+        LIMIT :limit
         """)
-    Optional<Directory> findFirstExpiredDirectory(
+    List<Directory> findExpiredDirectories(
         @Param("baseTime") LocalDateTime baseTime,
-        @Param("lastId") long lastId);
+        @Param("lastId") long lastId,
+        @Param("limit") int limit);
 }

--- a/src/main/java/com/driveu/server/domain/file/application/S3FileStorageService.java
+++ b/src/main/java/com/driveu/server/domain/file/application/S3FileStorageService.java
@@ -16,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -90,13 +89,8 @@ public class S3FileStorageService {
         }
     }
 
-    @Async("asyncExecutor")
     public void deleteFile(String key) {
-        try {
-            amazonS3Client.deleteObject(bucketName, key);
-            log.info("[S3Service] S3 파일 삭제 성공: {}", key);
-        } catch (Exception e) {
-            log.error("[S3Service] S3 파일 삭제 실패: {}", key, e);
-        }
+        amazonS3Client.deleteObject(bucketName, key);
+        log.info("[S3Service] S3 파일 삭제 성공: {}", key);
     }
 }

--- a/src/main/java/com/driveu/server/domain/resource/dao/ResourceRepository.java
+++ b/src/main/java/com/driveu/server/domain/resource/dao/ResourceRepository.java
@@ -11,7 +11,6 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 public interface ResourceRepository extends JpaRepository<Resource, Long> {
 
@@ -73,10 +72,11 @@ public interface ResourceRepository extends JpaRepository<Resource, Long> {
         AND r.deletedAt < :baseTime
         AND r.id > :lastId
         ORDER BY r.id ASC
-        LIMIT 1
+        LIMIT :limit
         """)
-    Optional<Resource> findFirstExpiredResource(
+    List<Resource> findExpiredResources(
         @Param("baseTime") LocalDateTime baseTime,
-        @Param("lastId") long lastId);
+        @Param("lastId") long lastId,
+        @Param("limit") int limit);
 
 }

--- a/src/main/java/com/driveu/server/domain/resource/dao/ResourceRepository.java
+++ b/src/main/java/com/driveu/server/domain/resource/dao/ResourceRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface ResourceRepository extends JpaRepository<Resource, Long> {
 
@@ -65,5 +66,17 @@ public interface ResourceRepository extends JpaRepository<Resource, Long> {
     List<Resource> findChildrenInTrash(@Param("directoryId") Long directoryId, @Param("deletionTime") LocalDateTime deletionTime, Sort sort);
 
     List<Resource> findAllByIsDeletedTrueAndDeletedAtBefore(LocalDateTime deletedAtBefore);
+
+    @Query("""
+        SELECT r FROM Resource r
+        WHERE r.isDeleted = true
+        AND r.deletedAt < :baseTime
+        AND r.id > :lastId
+        ORDER BY r.id ASC
+        LIMIT 1
+        """)
+    Optional<Resource> findFirstExpiredResource(
+        @Param("baseTime") LocalDateTime baseTime,
+        @Param("lastId") long lastId);
 
 }

--- a/src/main/java/com/driveu/server/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/driveu/server/domain/user/dao/UserRepository.java
@@ -1,10 +1,16 @@
 package com.driveu.server.domain.user.dao;
 
 import com.driveu.server.domain.user.domain.User;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    @Modifying
+    @Query("UPDATE User u SET u.usedStorage = GREATEST(u.usedStorage - :size, 0) WHERE u.id = :id")
+    void decreaseUsedStorage(@Param("id") Long id, @Param("size") Long size);
 }

--- a/src/main/java/com/driveu/server/global/batch/config/BatchJobController.java
+++ b/src/main/java/com/driveu/server/global/batch/config/BatchJobController.java
@@ -1,16 +1,22 @@
 package com.driveu.server.global.batch.config;
 
 import java.time.LocalDateTime;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.launch.JobOperator;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -22,13 +28,21 @@ import org.springframework.web.bind.annotation.RestController;
 @Profile("dev")
 public class BatchJobController {
 
+    private static final String JOB_NAME = "trashCleanupJob";
+
     private final JobLauncher jobLauncher;
     private final Job trashCleanupJob;
+    private final JobExplorer jobExplorer;
+    private final JobOperator jobOperator;
 
     public BatchJobController(JobLauncher jobLauncher,
-                               @Qualifier("trashCleanupJob") Job trashCleanupJob) {
+                              @Qualifier("trashCleanupJob") Job trashCleanupJob,
+                              JobExplorer jobExplorer,
+                              JobOperator jobOperator) {
         this.jobLauncher = jobLauncher;
         this.trashCleanupJob = trashCleanupJob;
+        this.jobExplorer = jobExplorer;
+        this.jobOperator = jobOperator;
     }
 
     /**
@@ -46,5 +60,60 @@ public class BatchJobController {
         JobExecution execution = jobLauncher.run(trashCleanupJob, params);
         return ResponseEntity.ok("status=" + execution.getStatus()
                 + ", jobExecutionId=" + execution.getId());
+    }
+
+    /**
+     * 마지막 실패 실행 조회: GET /internal/batch/trash-cleanup/last-failed
+     */
+    @GetMapping("/trash-cleanup/last-failed")
+    public ResponseEntity<String> getLastFailedExecution() {
+        JobExecution lastFailed = findLastFailedExecution();
+        if (lastFailed == null) {
+            return ResponseEntity.ok("실패한 JobExecution이 없습니다.");
+        }
+        return ResponseEntity.ok(
+                "jobExecutionId=" + lastFailed.getId()
+                + ", startTime=" + lastFailed.getStartTime()
+                + ", jobParameters=" + lastFailed.getJobParameters()
+        );
+    }
+
+    /**
+     * 수동 Restart: POST /internal/batch/trash-cleanup/restart
+     * 마지막으로 실패한 JobExecution을 파라미터 그대로 재시작
+     */
+    @PostMapping("/trash-cleanup/restart")
+    public ResponseEntity<String> restartLastFailed() throws Exception {
+        JobExecution lastFailed = findLastFailedExecution();
+        if (lastFailed == null) {
+            return ResponseEntity.badRequest().body("재시작할 실패 JobExecution이 없습니다.");
+        }
+
+        long failedExecutionId = lastFailed.getId();
+        log.info("[BatchJobController] 수동 재시작 요청: executionId={}, params={}",
+                failedExecutionId, lastFailed.getJobParameters());
+
+        // JobOperator.restart() → 실패한 executionId 기준으로 동일 파라미터 재시작
+        // 이미 COMPLETED된 Step은 건너뛰고 FAILED Step부터 이어서 실행
+        Long newExecutionId = jobOperator.restart(failedExecutionId);
+
+        JobExecution newExecution = jobExplorer.getJobExecution(newExecutionId);
+        String status = newExecution != null ? newExecution.getStatus().toString() : "UNKNOWN";
+
+        log.info("[BatchJobController] 재시작 완료: newExecutionId={}, status={}", newExecutionId, status);
+        return ResponseEntity.ok(
+                "재시작 완료: newExecutionId=" + newExecutionId + ", status=" + status
+        );
+    }
+
+    private JobExecution findLastFailedExecution() {
+        // getJobInstances()는 최신 JobInstance 순으로 반환
+        // getLastJobExecution()으로 인스턴스당 마지막 실행만 조회 → FAILED 첫 번째가 가장 최근 실패
+        return jobExplorer.getJobInstances(JOB_NAME, 0, 10).stream()
+                .map(jobExplorer::getLastJobExecution)
+                .filter(Objects::nonNull)
+                .filter(e -> e.getStatus() == BatchStatus.FAILED)
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/com/driveu/server/global/batch/config/BatchJobController.java
+++ b/src/main/java/com/driveu/server/global/batch/config/BatchJobController.java
@@ -1,0 +1,50 @@
+package com.driveu.server.global.batch.config;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/internal/batch")
+@Profile("dev")
+public class BatchJobController {
+
+    private final JobLauncher jobLauncher;
+    private final Job trashCleanupJob;
+
+    public BatchJobController(JobLauncher jobLauncher,
+                               @Qualifier("trashCleanupJob") Job trashCleanupJob) {
+        this.jobLauncher = jobLauncher;
+        this.trashCleanupJob = trashCleanupJob;
+    }
+
+    /**
+     * 수동 실행: POST /internal/batch/trash-cleanup?daysAgo=30
+     */
+    @PostMapping("/trash-cleanup")
+    public ResponseEntity<String> runTrashCleanup(
+            @RequestParam(defaultValue = "30") int daysAgo) throws Exception {
+
+        JobParameters params = new JobParametersBuilder()
+                .addLocalDateTime("baseTime", LocalDateTime.now().minusDays(daysAgo))
+                .addLong("run.id", System.currentTimeMillis())
+                .toJobParameters();
+
+        JobExecution execution = jobLauncher.run(trashCleanupJob, params);
+        return ResponseEntity.ok("status=" + execution.getStatus()
+                + ", jobExecutionId=" + execution.getId());
+    }
+}

--- a/src/main/java/com/driveu/server/global/batch/config/TrashCleanupJobConfig.java
+++ b/src/main/java/com/driveu/server/global/batch/config/TrashCleanupJobConfig.java
@@ -1,0 +1,99 @@
+package com.driveu.server.global.batch.config;
+
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.driveu.server.domain.directory.domain.Directory;
+import com.driveu.server.domain.resource.domain.Resource;
+import com.driveu.server.global.batch.trash.listener.DirectorySkipListener;
+import com.driveu.server.global.batch.trash.listener.ResourceSkipListener;
+import com.driveu.server.global.batch.trash.listener.S3RetryListener;
+import com.driveu.server.global.batch.trash.reader.ExpiredDirectoryReader;
+import com.driveu.server.global.batch.trash.reader.ExpiredResourceReader;
+import com.driveu.server.global.batch.trash.writer.DirectoryCleanupWriter;
+import com.driveu.server.global.batch.trash.writer.ResourceCleanupWriter;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class TrashCleanupJobConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final CircuitBreakerRegistry circuitBreakerRegistry;
+
+    private final ExpiredResourceReader expiredResourceReader;
+    private final ResourceCleanupWriter resourceCleanupWriter;
+    private final ResourceSkipListener resourceSkipListener;
+    private final S3RetryListener s3RetryListener;
+
+    private final ExpiredDirectoryReader expiredDirectoryReader;
+    private final DirectoryCleanupWriter directoryCleanupWriter;
+    private final DirectorySkipListener directorySkipListener;
+
+    @Bean
+    public CircuitBreaker s3DeleteCircuitBreaker() {
+        return circuitBreakerRegistry.circuitBreaker("s3Delete");
+    }
+
+    @Bean
+    public Job trashCleanupJob() {
+        return new JobBuilder("trashCleanupJob", jobRepository)
+                .start(resourceCleanupStep())
+                .next(directoryCleanupStep())
+                .build();
+    }
+
+    @Bean
+    public Step resourceCleanupStep() {
+        return new StepBuilder("resourceCleanupStep", jobRepository)
+                .<Resource, Resource>chunk(100, transactionManager)
+                .reader(expiredResourceReader)
+                .writer(resourceCleanupWriter)
+                .faultTolerant()
+                // Retry
+                .retry(AmazonS3Exception.class) // 재시도 대상 예외
+                .retry(TransientDataAccessException.class) // DB 커넥션 일시적으로 못 얻음
+                .retryLimit(3) // 최대 3회 재시도
+                // 지수 백오프
+                .backOffPolicy(new ExponentialBackOffPolicy() {{
+                    setInitialInterval(1000); // 1초
+                    setMultiplier(2.0); // 2배씩
+                    setMaxInterval(10000); // 최대 10초
+                }})
+
+                // Skip
+                .skip(AmazonS3Exception.class)           // retry 소진 후 skip
+                .skip(CallNotPermittedException.class)      // Circuit OPEN 시 즉시 skip
+                .skipLimit(50)
+
+                .listener(resourceSkipListener)
+                .listener(s3RetryListener)
+                .startLimit(3) // Step 자체 실행 횟수 제한 (무한 재시작 방지)
+                .build();
+    }
+
+    @Bean
+    public Step directoryCleanupStep() {
+        return new StepBuilder("directoryCleanupStep", jobRepository)
+                .<Directory, Directory>chunk(100, transactionManager)
+                .reader(expiredDirectoryReader)
+                .writer(directoryCleanupWriter)
+                .faultTolerant()
+                .skipLimit(20)
+                .listener(directorySkipListener)
+                .startLimit(3)
+                .build();
+    }
+}

--- a/src/main/java/com/driveu/server/global/batch/config/TrashCleanupJobConfig.java
+++ b/src/main/java/com/driveu/server/global/batch/config/TrashCleanupJobConfig.java
@@ -62,6 +62,7 @@ public class TrashCleanupJobConfig {
                 .reader(expiredResourceReader)
                 .writer(resourceCleanupWriter)
                 .faultTolerant()
+
                 // Retry
                 .retry(AmazonS3Exception.class) // 재시도 대상 예외
                 .retry(TransientDataAccessException.class) // DB 커넥션 일시적으로 못 얻음

--- a/src/main/java/com/driveu/server/global/batch/trash/listener/DirectorySkipListener.java
+++ b/src/main/java/com/driveu/server/global/batch/trash/listener/DirectorySkipListener.java
@@ -1,0 +1,29 @@
+package com.driveu.server.global.batch.trash.listener;
+
+import com.driveu.server.domain.batch.dao.SkipLogRepository;
+import com.driveu.server.domain.batch.domain.SkipLog;
+import com.driveu.server.domain.directory.domain.Directory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.SkipListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DirectorySkipListener implements SkipListener<Directory, Directory> {
+
+    private final SkipLogRepository skipLogRepository;
+
+    @Override
+    public void onSkipInProcess(Directory item, Throwable t) {
+        log.warn("[DirectorySkipListener] PROCESS 단계 스킵: directoryId={}, reason={}", item.getId(), t.getMessage());
+        skipLogRepository.save(SkipLog.of("DIRECTORY_PROCESS", item.getId(), t.getMessage()));
+    }
+
+    @Override
+    public void onSkipInWrite(Directory item, Throwable t) {
+        log.warn("[DirectorySkipListener] WRITE 단계 스킵: directoryId={}, reason={}", item.getId(), t.getMessage());
+        skipLogRepository.save(SkipLog.of("DIRECTORY_WRITE", item.getId(), t.getMessage()));
+    }
+}

--- a/src/main/java/com/driveu/server/global/batch/trash/listener/ResourceSkipListener.java
+++ b/src/main/java/com/driveu/server/global/batch/trash/listener/ResourceSkipListener.java
@@ -1,0 +1,35 @@
+package com.driveu.server.global.batch.trash.listener;
+
+import com.driveu.server.domain.batch.dao.SkipLogRepository;
+import com.driveu.server.domain.batch.domain.SkipLog;
+import com.driveu.server.domain.resource.domain.Resource;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.SkipListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ResourceSkipListener implements SkipListener<Resource, Resource> {
+
+    private final SkipLogRepository skipLogRepository;
+
+    @Override
+    public void onSkipInProcess(Resource item, Throwable t) {
+        log.warn("[ResourceSkipListener] PROCESS 단계 스킵: resourceId={}, reason={}", item.getId(), t.getMessage());
+        skipLogRepository.save(SkipLog.of("RESOURCE_PROCESS", item.getId(), t.getMessage()));
+    }
+
+    @Override
+    public void onSkipInWrite(Resource item, Throwable t) {
+        if (t instanceof CallNotPermittedException) {
+            log.warn("[ResourceSkipListener] Circuit OPEN - S3 요청 차단, 스킵: resourceId={}", item.getId());
+            skipLogRepository.save(SkipLog.of("RESOURCE_WRITE_CIRCUIT_OPEN", item.getId(), t.getMessage()));
+        } else {
+            log.warn("[ResourceSkipListener] WRITE 단계 스킵: resourceId={}, reason={}", item.getId(), t.getMessage());
+            skipLogRepository.save(SkipLog.of("RESOURCE_WRITE", item.getId(), t.getMessage()));
+        }
+    }
+}

--- a/src/main/java/com/driveu/server/global/batch/trash/listener/S3RetryListener.java
+++ b/src/main/java/com/driveu/server/global/batch/trash/listener/S3RetryListener.java
@@ -1,0 +1,28 @@
+package com.driveu.server.global.batch.trash.listener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class S3RetryListener implements RetryListener {
+
+    @Override
+    public <T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback, Throwable t) {
+        log.warn("[Retry] {}회 실패: 예외={}, 원인={}",
+                context.getRetryCount(),
+                t.getClass().getSimpleName(),
+                t.getMessage());
+    }
+
+    @Override
+    public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback, Throwable t) {
+        if (t != null) {
+            log.error("[Retry] {}회 모두 실패 → Skip 또는 Job 실패: {}",
+                    context.getRetryCount(), t.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/driveu/server/global/batch/trash/reader/ExpiredDirectoryReader.java
+++ b/src/main/java/com/driveu/server/global/batch/trash/reader/ExpiredDirectoryReader.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ExpiredDirectoryReader implements ItemStreamReader<Directory> {
 
-    private static final int BUFFER_SIZE = 500;
+    private static final int BUFFER_SIZE = 100;
 
     private final DirectoryRepository directoryRepository;
 

--- a/src/main/java/com/driveu/server/global/batch/trash/reader/ExpiredDirectoryReader.java
+++ b/src/main/java/com/driveu/server/global/batch/trash/reader/ExpiredDirectoryReader.java
@@ -1,0 +1,53 @@
+package com.driveu.server.global.batch.trash.reader;
+
+import com.driveu.server.domain.directory.dao.DirectoryRepository;
+import com.driveu.server.domain.directory.domain.Directory;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class ExpiredDirectoryReader implements ItemStreamReader<Directory> {
+
+    private final DirectoryRepository directoryRepository;
+
+    @Value("#{jobParameters['baseTime']}")
+    private LocalDateTime baseTime;
+
+    private long lastProcessedId = 0;
+
+    @Override
+    public void open(ExecutionContext ctx) {
+        if (ctx.containsKey("directory.last.id")) {
+            lastProcessedId = ctx.getLong("directory.last.id");
+            log.info("[Step2] {}번부터 재시작", lastProcessedId);
+        }
+    }
+
+    @Override
+    public void update(ExecutionContext ctx) {
+        ctx.putLong("directory.last.id", lastProcessedId);
+    }
+
+    @Override
+    public Directory read() {
+        return directoryRepository.findFirstExpiredDirectory(baseTime, lastProcessedId)
+                .map(directory -> {
+                    lastProcessedId = directory.getId();
+                    return directory;
+                })
+                .orElse(null);
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/src/main/java/com/driveu/server/global/batch/trash/reader/ExpiredDirectoryReader.java
+++ b/src/main/java/com/driveu/server/global/batch/trash/reader/ExpiredDirectoryReader.java
@@ -3,6 +3,8 @@ package com.driveu.server.global.batch.trash.reader;
 import com.driveu.server.domain.directory.dao.DirectoryRepository;
 import com.driveu.server.domain.directory.domain.Directory;
 import java.time.LocalDateTime;
+import java.util.ArrayDeque;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -17,12 +19,15 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ExpiredDirectoryReader implements ItemStreamReader<Directory> {
 
+    private static final int BUFFER_SIZE = 500;
+
     private final DirectoryRepository directoryRepository;
 
     @Value("#{jobParameters['baseTime']}")
     private LocalDateTime baseTime;
 
     private long lastProcessedId = 0;
+    private final ArrayDeque<Directory> buffer = new ArrayDeque<>();
 
     @Override
     public void open(ExecutionContext ctx) {
@@ -39,15 +44,20 @@ public class ExpiredDirectoryReader implements ItemStreamReader<Directory> {
 
     @Override
     public Directory read() {
-        return directoryRepository.findFirstExpiredDirectory(baseTime, lastProcessedId)
-                .map(directory -> {
-                    lastProcessedId = directory.getId();
-                    return directory;
-                })
-                .orElse(null);
+        if (buffer.isEmpty()) {
+            List<Directory> batch = directoryRepository.findExpiredDirectories(baseTime, lastProcessedId, BUFFER_SIZE);
+            buffer.addAll(batch);
+        }
+        if (buffer.isEmpty()) {
+            return null;
+        }
+        Directory directory = buffer.poll();
+        lastProcessedId = directory.getId();
+        return directory;
     }
 
     @Override
     public void close() {
+        buffer.clear();
     }
 }

--- a/src/main/java/com/driveu/server/global/batch/trash/reader/ExpiredResourceReader.java
+++ b/src/main/java/com/driveu/server/global/batch/trash/reader/ExpiredResourceReader.java
@@ -3,6 +3,8 @@ package com.driveu.server.global.batch.trash.reader;
 import com.driveu.server.domain.resource.dao.ResourceRepository;
 import com.driveu.server.domain.resource.domain.Resource;
 import java.time.LocalDateTime;
+import java.util.ArrayDeque;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -15,8 +17,10 @@ import org.springframework.stereotype.Component;
 @Component
 @StepScope
 @RequiredArgsConstructor
-// open → (read → update) 반복 → close 순서로 호출
 public class ExpiredResourceReader implements ItemStreamReader<Resource> {
+
+    // 한 번에 DB에서 읽어올 개수
+    private static final int BUFFER_SIZE = 100;
 
     private final ResourceRepository resourceRepository;
 
@@ -24,12 +28,10 @@ public class ExpiredResourceReader implements ItemStreamReader<Resource> {
     private LocalDateTime baseTime;
 
     private long lastProcessedId = 0;
+    private final ArrayDeque<Resource> buffer = new ArrayDeque<>();
 
     /**
-     * 처음 실행: "resource.last.id" 키가 없으므로 lastProcessedId = 0 그대로 시작 / 재시작(Restart): 이전에 중단된 지점의 id가 저장되어 있으면 그 값으로
-     * lastProcessedId를 복원 → 처음부터 다시 읽지 않고 중단 지점부터 재개
-     *
-     * @param ctx: Spring batch의 상태 저장소
+     * 처음 실행: "resource.last.id" 키가 없으므로 lastProcessedId = 0 그대로 시작 재시작(Restart): 마지막으로 커밋된 ID를 복원 → 중단 지점부터 재개
      */
     @Override
     public void open(ExecutionContext ctx) {
@@ -40,9 +42,7 @@ public class ExpiredResourceReader implements ItemStreamReader<Resource> {
     }
 
     /**
-     * chunk 단위로 처리가 완료될 때마다 호출됨 현재 lastProcessedId를 ExecutionContext에 저장 -> 서버가 중간에 다운되어도 재시작시 open에서 복구 가능
-     *
-     * @param ctx to be updated
+     * 청크 커밋 시점마다 호출 → lastProcessedId를 저장해 장애 시 재시작 지점 보장 버퍼 내 미처리 항목은 재시작 시 다시 조회되므로 중복/누락 없음
      */
     @Override
     public void update(ExecutionContext ctx) {
@@ -51,15 +51,21 @@ public class ExpiredResourceReader implements ItemStreamReader<Resource> {
 
     @Override
     public Resource read() {
-        return resourceRepository.findFirstExpiredResource(baseTime, lastProcessedId)
-                .map(resource -> {
-                    lastProcessedId = resource.getId();
-                    return resource;
-                })
-                .orElse(null);
+        if (buffer.isEmpty()) {
+            List<Resource> batch = resourceRepository.findExpiredResources(baseTime, lastProcessedId, BUFFER_SIZE);
+            buffer.addAll(batch);
+        }
+        // 처리할 데이터 없음
+        if (buffer.isEmpty()) {
+            return null;
+        }
+        Resource resource = buffer.poll(); // 버퍼(Queue)의 가장 첫 번째 아이템을 리턴
+        lastProcessedId = resource.getId();
+        return resource;
     }
 
     @Override
     public void close() {
+        buffer.clear();
     }
 }

--- a/src/main/java/com/driveu/server/global/batch/trash/reader/ExpiredResourceReader.java
+++ b/src/main/java/com/driveu/server/global/batch/trash/reader/ExpiredResourceReader.java
@@ -1,0 +1,65 @@
+package com.driveu.server.global.batch.trash.reader;
+
+import com.driveu.server.domain.resource.dao.ResourceRepository;
+import com.driveu.server.domain.resource.domain.Resource;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@StepScope
+@RequiredArgsConstructor
+// open → (read → update) 반복 → close 순서로 호출
+public class ExpiredResourceReader implements ItemStreamReader<Resource> {
+
+    private final ResourceRepository resourceRepository;
+
+    @Value("#{jobParameters['baseTime']}")
+    private LocalDateTime baseTime;
+
+    private long lastProcessedId = 0;
+
+    /**
+     * 처음 실행: "resource.last.id" 키가 없으므로 lastProcessedId = 0 그대로 시작 / 재시작(Restart): 이전에 중단된 지점의 id가 저장되어 있으면 그 값으로
+     * lastProcessedId를 복원 → 처음부터 다시 읽지 않고 중단 지점부터 재개
+     *
+     * @param ctx: Spring batch의 상태 저장소
+     */
+    @Override
+    public void open(ExecutionContext ctx) {
+        if (ctx.containsKey("resource.last.id")) {
+            lastProcessedId = ctx.getLong("resource.last.id");
+            log.info("[Step1] {}번부터 재시작", lastProcessedId);
+        }
+    }
+
+    /**
+     * chunk 단위로 처리가 완료될 때마다 호출됨 현재 lastProcessedId를 ExecutionContext에 저장 -> 서버가 중간에 다운되어도 재시작시 open에서 복구 가능
+     *
+     * @param ctx to be updated
+     */
+    @Override
+    public void update(ExecutionContext ctx) {
+        ctx.putLong("resource.last.id", lastProcessedId);
+    }
+
+    @Override
+    public Resource read() {
+        return resourceRepository.findFirstExpiredResource(baseTime, lastProcessedId)
+                .map(resource -> {
+                    lastProcessedId = resource.getId();
+                    return resource;
+                })
+                .orElse(null);
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/src/main/java/com/driveu/server/global/batch/trash/writer/DirectoryCleanupWriter.java
+++ b/src/main/java/com/driveu/server/global/batch/trash/writer/DirectoryCleanupWriter.java
@@ -1,0 +1,43 @@
+package com.driveu.server.global.batch.trash.writer;
+
+import com.driveu.server.domain.directory.dao.DirectoryHierarchyRepository;
+import com.driveu.server.domain.directory.dao.DirectoryRepository;
+import com.driveu.server.domain.directory.domain.Directory;
+import com.driveu.server.domain.resource.dao.ResourceDirectoryRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class DirectoryCleanupWriter implements ItemWriter<Directory> {
+
+    private final DirectoryHierarchyRepository directoryHierarchyRepository;
+    private final ResourceDirectoryRepository resourceDirectoryRepository;
+    private final DirectoryRepository directoryRepository;
+
+    @Override
+    @Transactional
+    public void write(Chunk<? extends Directory> chunk) {
+        List<Directory> directories = new ArrayList<>(chunk.getItems());
+        if (directories.isEmpty()) {
+            return;
+        }
+
+        List<Long> dirIds = directories.stream().map(Directory::getId).toList();
+
+        directoryHierarchyRepository.deleteAllByDirectoryIds(dirIds);
+        resourceDirectoryRepository.deleteAllByDirectoryIn(directories);
+        directoryRepository.deleteAllInBatch(directories);
+
+        log.info("[Step2] 디렉토리 {}건 삭제 완료", directories.size());
+    }
+}

--- a/src/main/java/com/driveu/server/global/batch/trash/writer/ResourceCleanupWriter.java
+++ b/src/main/java/com/driveu/server/global/batch/trash/writer/ResourceCleanupWriter.java
@@ -1,0 +1,113 @@
+package com.driveu.server.global.batch.trash.writer;
+
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.driveu.server.domain.file.application.S3FileStorageService;
+import com.driveu.server.domain.question.dao.QuestionResourceRepository;
+import com.driveu.server.domain.resource.dao.ResourceDirectoryRepository;
+import com.driveu.server.domain.resource.dao.ResourceRepository;
+import com.driveu.server.domain.resource.domain.File;
+import com.driveu.server.domain.resource.domain.Note;
+import com.driveu.server.domain.resource.domain.Resource;
+import com.driveu.server.domain.resource.domain.ResourceDirectory;
+import com.driveu.server.domain.summary.dao.SummaryRepository;
+import com.driveu.server.domain.user.dao.UserRepository;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class ResourceCleanupWriter implements ItemWriter<Resource> {
+
+    private final QuestionResourceRepository questionResourceRepository;
+    private final SummaryRepository summaryRepository;
+    private final ResourceDirectoryRepository resourceDirectoryRepository;
+    private final ResourceRepository resourceRepository;
+    private final S3FileStorageService s3FileStorageService;
+    private final UserRepository userRepository;
+    private final CircuitBreaker s3DeleteCircuitBreaker;
+
+    @Override
+    @Transactional
+    public void write(Chunk<? extends Resource> chunk) {
+        List<Resource> resources = new ArrayList<>(chunk.getItems());
+        if (resources.isEmpty()) {
+            return;
+        }
+
+        List<Long> resourceIds = resources.stream().map(Resource::getId).toList();
+        List<Long> noteIds = resources.stream()
+                .filter(Note.class::isInstance)
+                .map(Resource::getId)
+                .toList();
+        List<File> files = resources.stream()
+                .filter(File.class::isInstance)
+                .map(File.class::cast)
+                .toList();
+
+        // 스토리지 복구 사전 계산 (deleteAllByResourceIn 호출 전 ResourceDirectory 참조 가능)
+        Map<Long, Long> sizePerUser = calculateSizePerUser(files);
+
+        // 1. 연관 엔티티 삭제 (FK 순서 준수)
+        // Question은 유지하고 삭제된 리소스와의 연결(QuestionResource)만 제거
+        questionResourceRepository.deleteAllByResourceIds(resourceIds);
+        if (!noteIds.isEmpty()) {
+            summaryRepository.deleteAllByNoteIds(noteIds);
+        }
+        resourceDirectoryRepository.deleteAllByResourceIn(resources);
+
+        // 2. S3 삭제 - Circuit Breaker 적용
+        // Circuit OPEN 시 CallNotPermittedException 발생 → 상위로 전파 → Skip 처리
+        for (File file : files) {
+            String path = file.getS3Path();
+            if (path == null) {
+                continue;
+            }
+            try {
+                s3DeleteCircuitBreaker.executeRunnable(() -> s3FileStorageService.deleteFile(path));
+            } catch (AmazonS3Exception e) {
+                if ("NoSuchKey".equals(e.getErrorCode())) {
+                    log.warn("[Step1] S3 파일 없음 (이미 삭제됨): key={}", path);
+                } else {
+                    throw e;  // Retry 대상
+                }
+            }
+        }
+
+        // 3. Resource DB 삭제
+        resourceRepository.deleteAllByIdInBatch(resourceIds);
+
+        // 4. 스토리지 복구 (벌크 UPDATE - 사용자 수만큼 단건 UPDATE)
+        for (Map.Entry<Long, Long> entry : sizePerUser.entrySet()) {
+            userRepository.decreaseUsedStorage(entry.getKey(), entry.getValue());
+        }
+
+        log.info("[Step1] 리소스 {}건 삭제 완료", resources.size());
+    }
+
+    private Map<Long, Long> calculateSizePerUser(List<File> files) {
+        Map<Long, Long> sizePerUser = new HashMap<>();
+        for (File file : files) {
+            List<ResourceDirectory> rds = file.getResourceDirectories();
+            if (!rds.isEmpty()) {
+                Long ownerId = rds.getFirst().getDirectory()
+                        .getUserSemester().getUser().getId();
+                sizePerUser.merge(ownerId, file.getSize(), Long::sum);
+            } else {
+                log.warn("[Step1] ResourceDirectory 없는 파일: fileId={}", file.getId());
+            }
+        }
+        return sizePerUser;
+    }
+}

--- a/src/main/java/com/driveu/server/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/driveu/server/global/config/security/SecurityConfig.java
@@ -62,7 +62,8 @@ public class SecurityConfig {
                         registry
                                 .requestMatchers("/api/auth/google", "/api/auth/code/google").permitAll() // 로그인 api 허용
                                 .requestMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**",
-                                        "/swagger-resources/**", "/webjars/**").permitAll() // 스웨거 허용
+                                        "/swagger-resources/**", "/webjars/**", "/internal/batch/trash-cleanup")
+                                .permitAll() // 스웨거 허용
                                 .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider, tokenExtractor),

--- a/src/main/java/com/driveu/server/global/scheduler/TrashCleanupScheduler.java
+++ b/src/main/java/com/driveu/server/global/scheduler/TrashCleanupScheduler.java
@@ -1,17 +1,38 @@
 package com.driveu.server.global.scheduler;
 
-import com.driveu.server.domain.trash.application.TrashCleanupService;
-import lombok.RequiredArgsConstructor;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
-@RequiredArgsConstructor
 public class TrashCleanupScheduler {
-    private final TrashCleanupService trashCleanupService;
+
+    private final JobLauncher jobLauncher;
+    private final Job trashCleanupJob;
+
+    public TrashCleanupScheduler(JobLauncher jobLauncher,
+                                 @Qualifier("trashCleanupJob") Job trashCleanupJob) {
+        this.jobLauncher = jobLauncher;
+        this.trashCleanupJob = trashCleanupJob;
+    }
 
     @Scheduled(cron = "0 0 0 * * *")
     public void autoDeleteExpiredTrash() {
-        trashCleanupService.deleteExpiredItems();
+        try {
+            JobParameters params = new JobParametersBuilder()
+                    .addLocalDateTime("baseTime", LocalDateTime.now().minusDays(30))
+                    .addLong("run.id", System.currentTimeMillis())
+                    .toJobParameters();
+            jobLauncher.run(trashCleanupJob, params);
+        } catch (Exception e) {
+            log.error("[TrashCleanupScheduler] 배치 실행 실패: {}", e.getMessage(), e);
+        }
     }
 }

--- a/src/main/java/com/driveu/server/global/scheduler/TrashCleanupScheduler.java
+++ b/src/main/java/com/driveu/server/global/scheduler/TrashCleanupScheduler.java
@@ -2,7 +2,9 @@ package com.driveu.server.global.scheduler;
 
 import java.time.LocalDateTime;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
@@ -13,6 +15,9 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class TrashCleanupScheduler {
+
+    // 최초 실행 1회 + 재시작 1회
+    private static final int MAX_ATTEMPTS = 2;
 
     private final JobLauncher jobLauncher;
     private final Job trashCleanupJob;
@@ -25,14 +30,37 @@ public class TrashCleanupScheduler {
 
     @Scheduled(cron = "0 0 0 * * *")
     public void autoDeleteExpiredTrash() {
-        try {
-            JobParameters params = new JobParametersBuilder()
-                    .addLocalDateTime("baseTime", LocalDateTime.now().minusDays(30))
-                    .addLong("run.id", System.currentTimeMillis())
-                    .toJobParameters();
-            jobLauncher.run(trashCleanupJob, params);
-        } catch (Exception e) {
-            log.error("[TrashCleanupScheduler] 배치 실행 실패: {}", e.getMessage(), e);
+        // run.id를 고정해야 같은 JobInstance로 인식 → Spring Batch가 실패 지점부터 재시작
+        JobParameters params = new JobParametersBuilder()
+                .addLocalDateTime("baseTime", LocalDateTime.now().minusDays(30))
+                .addLong("run.id", System.currentTimeMillis())
+                .toJobParameters();
+
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            try {
+                log.info("[TrashCleanupScheduler] 배치 시작 (시도={})", attempt);
+                JobExecution execution = jobLauncher.run(trashCleanupJob, params);
+                BatchStatus status = execution.getStatus();
+
+                if (status == BatchStatus.COMPLETED) {
+                    log.info("[TrashCleanupScheduler] 배치 완료 (시도={})", attempt);
+                    return;
+                }
+
+                if (status == BatchStatus.FAILED && attempt < MAX_ATTEMPTS) {
+                    log.warn("[TrashCleanupScheduler] 배치 실패 감지 → 즉시 재시작 (시도={}, executionId={})",
+                            attempt, execution.getId());
+                    // 루프 継続 → 동일 params로 재실행 → Spring Batch가 실패 Step부터 재시작
+                } else {
+                    log.error("[TrashCleanupScheduler] 최종 실패 (시도={}, status={}, executionId={})",
+                            attempt, status, execution.getId());
+                    return;
+                }
+
+            } catch (Exception e) {
+                log.error("[TrashCleanupScheduler] 배치 실행 예외 (시도={}): {}", attempt, e.getMessage(), e);
+                return;
+            }
         }
     }
 }

--- a/src/test/java/com/driveu/server/global/batch/ResourceCleanupRetryTest.java
+++ b/src/test/java/com/driveu/server/global/batch/ResourceCleanupRetryTest.java
@@ -1,0 +1,168 @@
+package com.driveu.server.global.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.driveu.server.domain.auth.domain.oauth.OauthProvider;
+import com.driveu.server.domain.batch.dao.SkipLogRepository;
+import com.driveu.server.domain.directory.dao.DirectoryRepository;
+import com.driveu.server.domain.directory.domain.Directory;
+import com.driveu.server.domain.file.application.S3FileStorageService;
+import com.driveu.server.domain.file.dao.FileRepository;
+import com.driveu.server.domain.resource.dao.ResourceDirectoryRepository;
+import com.driveu.server.domain.resource.domain.File;
+import com.driveu.server.domain.resource.domain.type.FileExtension;
+import com.driveu.server.domain.semester.dao.SemesterRepository;
+import com.driveu.server.domain.semester.dao.UserSemesterRepository;
+import com.driveu.server.domain.semester.domain.Semester;
+import com.driveu.server.domain.semester.domain.Term;
+import com.driveu.server.domain.semester.domain.UserSemester;
+import com.driveu.server.domain.user.dao.UserRepository;
+import com.driveu.server.domain.user.domain.User;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+
+@SpringBatchTest
+@SpringBootTest
+class ResourceCleanupRetryTest {
+
+    // JobLauncherTestUtils는 Job을 수동으로 세팅해야 정상 동작
+    @Autowired
+    private JobLauncher jobLauncher;
+    @Autowired
+    private JobRepository jobRepository;
+    @Autowired
+    @Qualifier("trashCleanupJob")
+    private Job trashCleanupJob;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private SemesterRepository semesterRepository;
+    @Autowired
+    private UserSemesterRepository userSemesterRepository;
+    @Autowired
+    private DirectoryRepository directoryRepository;
+    @Autowired
+    private FileRepository fileRepository;
+    @Autowired
+    private ResourceDirectoryRepository resourceDirectoryRepository;
+    @Autowired
+    private SkipLogRepository skipLogRepository;
+    @Autowired
+    private CircuitBreakerRegistry circuitBreakerRegistry;
+
+    @MockitoBean
+    private S3FileStorageService s3FileStorageService;
+
+    private JobLauncherTestUtils jobLauncherTestUtils;
+    private static final String S3_KEY = "test/file.pdf";
+
+    @BeforeEach
+    void setUp() {
+        jobLauncherTestUtils = new JobLauncherTestUtils();
+        jobLauncherTestUtils.setJobLauncher(jobLauncher);
+        jobLauncherTestUtils.setJobRepository(jobRepository);
+        jobLauncherTestUtils.setJob(trashCleanupJob);
+
+        User user = userRepository.save(User.of("테스트유저", "test@test.com", OauthProvider.GOOGLE));
+        Semester semester = semesterRepository.save(Semester.of(2026, Term.SPRING));
+        UserSemester userSemester = userSemesterRepository.save(UserSemester.of(user, semester, true));
+        Directory directory = directoryRepository.save(Directory.of(userSemester, "기본", true, 1));
+
+        File file = File.of("테스트파일", S3_KEY, FileExtension.PDF, 1024L);
+        file.softDeleteWithSetTime(LocalDateTime.now().minusDays(31));
+        file.addDirectory(directory);
+        fileRepository.save(file);
+    }
+
+    @AfterEach
+    void tearDown() {
+        skipLogRepository.deleteAll();
+        resourceDirectoryRepository.deleteAll();
+        fileRepository.deleteAll();
+        directoryRepository.deleteAll();
+        userSemesterRepository.deleteAll();
+        semesterRepository.deleteAll();
+        userRepository.deleteAll();
+        circuitBreakerRegistry.circuitBreaker("s3Delete").transitionToClosedState();
+    }
+
+    @Test
+    @DisplayName("S3 일시 장애: 2회 실패 후 3번째 성공 → COMPLETED")
+    void s3_일시_장애_재시도_후_성공() {
+        doThrow(new AmazonS3Exception("일시적 오류"))
+                .doThrow(new AmazonS3Exception("일시적 오류"))
+                .doNothing()
+                .when(s3FileStorageService).deleteFile(any());
+
+        JobExecution jobExecution = jobLauncherTestUtils.launchStep("resourceCleanupStep", params());
+        StepExecution stepExecution = jobExecution.getStepExecutions().iterator().next();
+
+        assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+        assertThat(stepExecution.getSkipCount()).isZero();
+        verify(s3FileStorageService, times(3)).deleteFile(S3_KEY);
+    }
+
+    @Test
+    @DisplayName("S3 완전 장애: 3회 모두 실패 → Skip 처리")
+    void s3_완전_장애_재시도_모두_실패_skip() {
+        doThrow(new AmazonS3Exception("S3 완전 장애"))
+                .when(s3FileStorageService).deleteFile(any());
+
+        JobExecution jobExecution = jobLauncherTestUtils.launchStep("resourceCleanupStep", params());
+        StepExecution stepExecution = jobExecution.getStepExecutions().iterator().next();
+
+        assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+        assertThat(stepExecution.getSkipCount()).isGreaterThan(0);
+        assertThat(skipLogRepository.findAll())
+                .anyMatch(log -> log.getStepName().equals("RESOURCE_WRITE"));
+    }
+
+    @Test
+    @DisplayName("Circuit OPEN: 즉시 CallNotPermittedException → Skip 처리")
+    void circuit_open_즉시_skip() {
+        CircuitBreaker cb = circuitBreakerRegistry.circuitBreaker("s3Delete");
+        cb.transitionToOpenState();
+
+        JobExecution jobExecution = jobLauncherTestUtils.launchStep("resourceCleanupStep", params());
+        StepExecution stepExecution = jobExecution.getStepExecutions().iterator().next();
+
+        assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+        assertThat(stepExecution.getSkipCount()).isGreaterThan(0);
+        verify(s3FileStorageService, times(0)).deleteFile(any());
+        assertThat(skipLogRepository.findAll())
+                .anyMatch(log -> log.getStepName().equals("RESOURCE_WRITE_CIRCUIT_OPEN"));
+    }
+
+    private JobParameters params() {
+        return new JobParametersBuilder()
+                .addLocalDateTime("baseTime", LocalDateTime.now().minusDays(30))
+                .addString("run.id", LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS")))
+                .toJobParameters();
+    }
+}

--- a/src/test/java/com/driveu/server/global/batch/ResourceCleanupSkipTest.java
+++ b/src/test/java/com/driveu/server/global/batch/ResourceCleanupSkipTest.java
@@ -1,0 +1,177 @@
+package com.driveu.server.global.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.driveu.server.domain.auth.domain.oauth.OauthProvider;
+import com.driveu.server.domain.batch.dao.SkipLogRepository;
+import com.driveu.server.domain.directory.dao.DirectoryRepository;
+import com.driveu.server.domain.directory.domain.Directory;
+import com.driveu.server.domain.file.application.S3FileStorageService;
+import com.driveu.server.domain.file.dao.FileRepository;
+import com.driveu.server.domain.resource.dao.ResourceDirectoryRepository;
+import com.driveu.server.domain.resource.domain.File;
+import com.driveu.server.domain.resource.domain.type.FileExtension;
+import com.driveu.server.domain.semester.dao.SemesterRepository;
+import com.driveu.server.domain.semester.dao.UserSemesterRepository;
+import com.driveu.server.domain.semester.domain.Semester;
+import com.driveu.server.domain.semester.domain.Term;
+import com.driveu.server.domain.semester.domain.UserSemester;
+import com.driveu.server.domain.user.dao.UserRepository;
+import com.driveu.server.domain.user.domain.User;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBatchTest
+@SpringBootTest
+class ResourceCleanupSkipTest {
+
+    @Autowired
+    private JobLauncher jobLauncher;
+    @Autowired
+    private JobRepository jobRepository;
+    @Autowired
+    @Qualifier("trashCleanupJob")
+    private Job trashCleanupJob;
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private SemesterRepository semesterRepository;
+    @Autowired
+    private UserSemesterRepository userSemesterRepository;
+    @Autowired
+    private DirectoryRepository directoryRepository;
+    @Autowired
+    private FileRepository fileRepository;
+    @Autowired
+    private ResourceDirectoryRepository resourceDirectoryRepository;
+    @Autowired
+    private SkipLogRepository skipLogRepository;
+    @Autowired
+    private CircuitBreakerRegistry circuitBreakerRegistry;
+
+    @MockitoBean
+    private S3FileStorageService s3FileStorageService;
+
+    private JobLauncherTestUtils jobLauncherTestUtils;
+    private Directory directory;
+
+    private static final String PASS_KEY_1 = "test/skip/pass-1.pdf";
+    private static final String FAIL_KEY = "test/skip/fail.pdf";
+    private static final String PASS_KEY_2 = "test/skip/pass-2.pdf";
+
+    @BeforeEach
+    void setUp() {
+        jobLauncherTestUtils = new JobLauncherTestUtils();
+        jobLauncherTestUtils.setJobLauncher(jobLauncher);
+        jobLauncherTestUtils.setJobRepository(jobRepository);
+        jobLauncherTestUtils.setJob(trashCleanupJob);
+
+        User user = userRepository.save(User.of("Skip테스트유저", "skip-test@test.com", OauthProvider.GOOGLE));
+        Semester semester = semesterRepository.save(Semester.of(2026, Term.SPRING));
+        UserSemester userSemester = userSemesterRepository.save(UserSemester.of(user, semester, true));
+        directory = directoryRepository.save(Directory.of(userSemester, "기본", true, 1));
+    }
+
+    @AfterEach
+    void tearDown() {
+        skipLogRepository.deleteAll();
+        resourceDirectoryRepository.deleteAll();
+        fileRepository.deleteAll();
+        directoryRepository.deleteAll();
+        userSemesterRepository.deleteAll();
+        semesterRepository.deleteAll();
+        userRepository.deleteAll();
+        circuitBreakerRegistry.circuitBreaker("s3Delete").transitionToClosedState();
+    }
+
+    @Test
+    @DisplayName("일부 파일 S3 오류: skip된 파일은 DB에 남고, 나머지는 정상 삭제")
+    void 일부_파일_skip_나머지_정상_삭제() {
+        // given
+        File passFile1 = saveExpiredFile("파일1", PASS_KEY_1);
+        File failFile = saveExpiredFile("파일2", FAIL_KEY);
+        File passFile2 = saveExpiredFile("파일3", PASS_KEY_2);
+
+        // FAIL_KEY만 항상 S3 오류 → PASS 키들은 mock 없음 → void 기본값 doNothing
+        doThrow(new AmazonS3Exception("S3 오류"))
+                .when(s3FileStorageService).deleteFile(FAIL_KEY);
+
+        // when
+        JobExecution jobExecution = jobLauncherTestUtils.launchStep("resourceCleanupStep", params());
+        StepExecution stepExecution = jobExecution.getStepExecutions().iterator().next();
+
+        // then
+        assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+        assertThat(stepExecution.getSkipCount()).isEqualTo(1);
+
+        // skip된 파일 → 트랜잭션 롤백으로 DB에 남음
+        assertThat(fileRepository.existsById(failFile.getId())).isTrue();
+        // 정상 파일 → DB에서 삭제 완료
+        assertThat(fileRepository.existsById(passFile1.getId())).isFalse();
+        assertThat(fileRepository.existsById(passFile2.getId())).isFalse();
+
+        // SkipLog: RESOURCE_WRITE 타입으로 실패 파일 ID만 정확히 1건 기록
+        var logs = skipLogRepository.findAll();
+        assertThat(logs).hasSize(1);
+        assertThat(logs.get(0).getStepName()).isEqualTo("RESOURCE_WRITE");
+        assertThat(logs.get(0).getResourceId()).isEqualTo(failFile.getId());
+    }
+
+    @Test
+    @DisplayName("S3 NoSuchKey: Writer 내부 흡수 → skip 없이 DB에서 정상 삭제")
+    void s3_NoSuchKey_skip_아님_정상_삭제() {
+        // given
+        File file = saveExpiredFile("파일", "test/skip/no-such-key.pdf");
+
+        AmazonS3Exception noSuchKeyEx = new AmazonS3Exception("The specified key does not exist.");
+        noSuchKeyEx.setErrorCode("NoSuchKey");
+        doThrow(noSuchKeyEx).when(s3FileStorageService).deleteFile("test/skip/no-such-key.pdf");
+
+        // when
+        JobExecution jobExecution = jobLauncherTestUtils.launchStep("resourceCleanupStep", params());
+        StepExecution stepExecution = jobExecution.getStepExecutions().iterator().next();
+
+        // then: NoSuchKey는 Writer 내부 catch에서 warn 후 continue → Batch skip 발생 안 함
+        assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+        assertThat(stepExecution.getSkipCount()).isZero();
+        assertThat(skipLogRepository.findAll()).isEmpty();
+        // S3에 파일이 없어도 DB 레코드는 정상 삭제됨
+        assertThat(fileRepository.existsById(file.getId())).isFalse();
+    }
+
+    private File saveExpiredFile(String title, String s3Key) {
+        File file = File.of(title, s3Key, FileExtension.PDF, 1024L);
+        file.softDeleteWithSetTime(LocalDateTime.now().minusDays(31));
+        file.addDirectory(directory);
+        return fileRepository.save(file);
+    }
+
+    private JobParameters params() {
+        return new JobParametersBuilder()
+                .addLocalDateTime("baseTime", LocalDateTime.now().minusDays(30))
+                .addString("run.id", LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS")))
+                .toJobParameters();
+    }
+}


### PR DESCRIPTION
﻿### 🥕 ISSUE

- closed #88 

---

### ✅ Key Changes
휴지통 리소스 정리 배치를 Spring Batch 기반으로 변경하고 Spring Batch 내결함성 3대 전략을 적용했습니다.

## 🔄 Retry - 일시적 오류 복구

일시적인 네트워크 오류나 DB 과부하 상황에서 자동 재시도합니다.

| 항목 | 설정값 |
|------|--------|
| 재시도 대상 | `AmazonS3Exception`, `TransientDataAccessException` |
| 최대 재시도 횟수 | 3회 |
| 백오프 초기 간격 | 1초 |
| 백오프 배수 | 2배 증가 |
| 백오프 최대 간격 | 10초 |

- **지수 백오프(ExponentialBackOff)** 적용으로 과부하 상태의 외부 서비스 회복 시간 확보
- **RetryListener** 로 재시도 발생 시 예외 유형·횟수 로깅

## 🔌 Circuit Breaker - 영구 장애 대응

| 상태 | 조건 |
|------|------|
| CLOSED → OPEN | 슬라이딩 윈도우 실패율 50% 초과 |
| OPEN → HALF-OPEN | 10초 경과 후 복구 테스트 |
| HALF-OPEN → CLOSED | 테스트 요청 성공 시 정상 복귀 |

---

## ⏭️ Skip - 데이터 결함 분리

단일 아이템 오류가 전체 배치를 중단시키지 않도록 분리합니다.

| 항목 | 설정값 |
|------|--------|
| Skip 대상 | `EntityNotFoundException`, `CallNotPermittedException`, `AmazonS3Exception` |
| 최대 Skip 허용 건수 | 50건 |

- **판단 기준:** 데이터 문제 및 Circuit Breaker OPEN → Skip / 일시적 시스템 오류 → Retry 우선
- **SkipListener** 로 실패 아이템을 `skip_log` 테이블에 기록하여 사후 추적 가능

---

## 🔁 Restart - 중단 지점 재개

배치가 중단되어도 처음부터 재실행하지 않습니다.

- **ExecutionContext** 에 `lastProcessedId` 를 청크 커밋마다 저장
  - Step 1: `resource.last.id`
  - Step 2: `directory.last.id`
- **ID 기반 커서** 로 중단 시점 이후 데이터만 조회
- **같은 JobParameter** 로 재실행 시 Spring Batch가 ExecutionContext 자동 복원
- **멱등성 확보:** 재시작 시 이미 삭제된 S3 파일의 `NoSuchKeyException` 무시 처리

---

## 🧪 테스트 체크리스트
- [ ] S3 일시 오류 시 최대 3회 재시도 후 Skip 처리 확인
- [ ] 지수 백오프 간격(1초 → 2초 → 4초) 동작 확인  
- [ ] skipLimit(50건) 초과 시 배치 FAILED 전환 확인
- [ ] 배치 중단 후 재시작 시 `lastProcessedId` 기반 재개 확인
- [ ] 재시작 시 이미 삭제된 S3 파일 `NoSuchKeyException` 무시 확인
- [ ] Circuit Breaker OPEN 상태에서 `CallNotPermittedException` Skip 확인

---

### 📢 To Reviewers
> S3 삭제 → DB 삭제 순서를 유지하며, S3 삭제 성공 후 DB 실패 시
> 재시작으로 DB 재처리가 가능하도록 설계했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 만료된 휴지통 데이터를 자동으로 정리하는 배치 시스템 추가 (매일 00:00 자동 실행)
  * S3 객체 삭제 및 사용자 저장소 사용량 자동 차감 기능 포함
  * 개발 프로필에서 수동 실행 및 재시작 API 제공

* **문서화**
  * README에 배치 시스템 구성 및 처리 흐름 설명 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->